### PR TITLE
fix: improve plex NFS reliability and reduce NAS I/O pressure

### DIFF
--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: actual
       VOLSYNC_CAPACITY: 2Gi
-      VOLSYNC_SCHEDULE: "45 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/n8n/ks.yaml
+++ b/kubernetes/apps/default/n8n/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: n8n
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "25 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/obsidian-couchdb/ks.yaml
+++ b/kubernetes/apps/default/obsidian-couchdb/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: obsidian-couchdb
       VOLSYNC_CAPACITY: 30Gi
-      VOLSYNC_SCHEDULE: "10 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: esphome
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "30 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: home-assistant
       VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_SCHEDULE: "0 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/home/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/ks.yaml
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: zigbee2mqtt
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "35 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/home/zwave/ks.yaml
+++ b/kubernetes/apps/home/zwave/ks.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       APP: zwave
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "40 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-nfs
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: csi-driver-nfs
+  interval: 1h
+  values:
+    controller:
+      replicas: 1
+    storageClass:
+      create: false

--- a/kubernetes/apps/kube-system/csi-driver-nfs/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/app/kustomization.yaml
@@ -4,6 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-  - ./nfs-media.yaml
   - ./ocirepository.yaml
-  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/kube-system/csi-driver-nfs/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: csi-driver-nfs
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.13.1
+  url: oci://ghcr.io/home-operations/charts-mirror/csi-driver-nfs

--- a/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: csi-driver-nfs
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/csi-driver-nfs/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: true

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./namespace.yaml
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
+  - ./csi-driver-nfs/ks.yaml
   - ./descheduler/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
   - ./e1000e-fix/ks.yaml

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: bazarr
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "0 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/board-game-collection/ks.yaml
+++ b/kubernetes/apps/media/board-game-collection/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: board-game-collection
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "35 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/booklore/ks.yaml
+++ b/kubernetes/apps/media/booklore/ks.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       APP: booklore
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "30 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: music-assistant
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "30 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -26,17 +26,21 @@ spec:
             probes:
               liveness:
                 enabled: true
+                custom: true
                 spec:
+                  httpGet:
+                    path: /identity
+                    port: &port 32400
                   periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 5
+                  timeoutSeconds: 10
+                  failureThreshold: 10
               readiness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /identity
-                    port: &port 32400
+                    port: *port
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5
@@ -106,9 +110,7 @@ spec:
       config:
         existingClaim: "{{ .Release.Name }}"
       media:
-        type: nfs
-        server: black-station.internal
-        path: /volume1/media
+        existingClaim: plex-media-nfs
         globalMounts:
           - path: /media
             readOnly: true

--- a/kubernetes/apps/media/plex/app/nfs-media.yaml
+++ b/kubernetes/apps/media/plex/app/nfs-media.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: plex-media-nfs
+spec:
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  mountOptions:
+    - nfsvers=4
+    - soft
+    - timeo=30
+    - retrans=3
+    - noatime
+    - nconnect=8
+    - rsize=1048576
+    - wsize=1048576
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: plex-media-nfs
+    volumeAttributes:
+      server: black-station.internal
+      share: /volume1/media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-media-nfs
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Mi
+  volumeName: plex-media-nfs

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -9,6 +9,8 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
+    - name: csi-driver-nfs
+      namespace: kube-system
     - name: intel-gpu-resource-driver
       namespace: kube-system
     - name: longhorn
@@ -21,7 +23,6 @@ spec:
     substitute:
       APP: plex
       VOLSYNC_CAPACITY: 30Gi
-      VOLSYNC_SCHEDULE: "5 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: prowlarr
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "5 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: qbittorrent
       VOLSYNC_CAPACITY: 2Gi
-      VOLSYNC_SCHEDULE: "10 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: qui
       VOLSYNC_CAPACITY: 2Gi
-      VOLSYNC_SCHEDULE: "40 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: radarr
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "20 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -18,7 +18,6 @@ spec:
     substitute:
       APP: recyclarr
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "45 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: seerr
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "20 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       APP: shelfmark
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "30 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -17,7 +17,6 @@ spec:
     substitute:
       APP: sonarr
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "15 */2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       APP: tautulli
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "15 1-23/2 * * *"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   sourcePVC: ${APP}
   trigger:
-    schedule: "${VOLSYNC_SCHEDULE:=0 */2 * * *}"
+    schedule: "0 4 * * *"
   kopia:
     accessModes:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}


### PR DESCRIPTION
## Summary

- **Consolidate Volsync backups to daily at 4:00am** — all 26 ReplicationSources were running every 2 hours, hammering the NAS (700MB RAM, spinning RAID1). Removed per-app `VOLSYNC_SCHEDULE` overrides; jitter init container handles staggering.
- **Add NFS CSI driver** (`csi-driver-nfs`) to enable per-volume mount options that bypass Linux kernel NFS mount deduplication.
- **Plex NFS soft mount** — media volume now uses `soft,timeo=30,retrans=3` via CSI, so NFS operations return errors instead of hanging indefinitely during NAS stalls.
- **Plex HTTP liveness probe** — changed from TCP socket (which always passes even when Plex is frozen) to HTTP GET `/identity`, so the pod auto-restarts after ~5min of unresponsiveness.

## Root Cause

Plex mid-movie freezes were caused by NFS I/O blocking. When the NAS became overloaded (from Volsync backups + qbittorrent writes), NFS operations hung, Plex threads blocked in uninterruptible sleep (CPU dropped from 0.08 to 0.004), and the `/identity` readiness probe failed. The TCP liveness probe kept passing (kernel socket stays open), so the pod stayed alive but unready — requiring manual restart.

## Test plan

- [x] CSI driver deployed and running on all nodes
- [x] Plex pod confirmed mounting NFS with `soft,timeo=30,retrans=3`
- [x] Liveness probe confirmed as HTTP GET `/identity`
- [ ] Monitor Plex stability during next NAS I/O pressure event
- [ ] Verify Volsync backups run correctly at 4:00am


Made with [Cursor](https://cursor.com)