### PR TITLE
fix(frigate): detect only, per-camera object lists

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -144,18 +144,11 @@ spec:
                 - dog
                 - cat
 
+            # Recording lives on the UniFi Dream Machine; Frigate only detects.
+            # Main streams stay defined in go2rtc below so the UI can pull them
+            # on demand for live view, but nothing holds them open 24/7.
             record:
-              enabled: true
-              continuous:
-                days: 0
-              motion:
-                days: 0
-              alerts:
-                retain:
-                  days: 14
-              detections:
-                retain:
-                  days: 7
+              enabled: false
 
             snapshots:
               enabled: true
@@ -193,9 +186,6 @@ spec:
               backyard:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/backyard
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/backyard_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]
@@ -206,9 +196,6 @@ spec:
               backyard_pool:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/backyard_pool
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/backyard_pool_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]
@@ -219,9 +206,6 @@ spec:
               entrance:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/entrance
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/entrance_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]
@@ -232,9 +216,6 @@ spec:
               living_room:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/living_room
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/living_room_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]
@@ -245,9 +226,6 @@ spec:
               family_room:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/family_room
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/family_room_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]
@@ -258,9 +236,6 @@ spec:
               service_yard:
                 ffmpeg:
                   inputs:
-                    - path: rtsp://127.0.0.1:8554/service_yard
-                      input_args: preset-rtsp-restream
-                      roles: [record]
                     - path: rtsp://127.0.0.1:8554/service_yard_sub
                       input_args: preset-rtsp-restream
                       roles: [detect]

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -137,12 +137,12 @@ spec:
               enabled: true
               fps: 5
 
+            # Baseline; each camera narrows this to what can plausibly appear in
+            # its frame. person and car surface as alerts, everything else as
+            # the quieter detections bucket.
             objects:
               track:
                 - person
-                - car
-                - dog
-                - cat
 
             # Recording lives on the UniFi Dream Machine; Frigate only detects.
             # Main streams stay defined in go2rtc below so the UI can pull them
@@ -193,6 +193,8 @@ spec:
                   streams:
                     Main: backyard
                     Sub: backyard_sub
+                objects:
+                  track: [person, dog, cat]
               backyard_pool:
                 ffmpeg:
                   inputs:
@@ -203,6 +205,8 @@ spec:
                   streams:
                     Main: backyard_pool
                     Sub: backyard_pool_sub
+                objects:
+                  track: [person, dog, cat]
               entrance:
                 ffmpeg:
                   inputs:
@@ -213,6 +217,8 @@ spec:
                   streams:
                     Main: entrance
                     Sub: entrance_sub
+                objects:
+                  track: [person, car]
               living_room:
                 ffmpeg:
                   inputs:
@@ -223,6 +229,8 @@ spec:
                   streams:
                     Main: living_room
                     Sub: living_room_sub
+                objects:
+                  track: [person, dog, cat]
               family_room:
                 ffmpeg:
                   inputs:
@@ -233,6 +241,8 @@ spec:
                   streams:
                     Main: family_room
                     Sub: family_room_sub
+                objects:
+                  track: [person, dog, cat]
               service_yard:
                 ffmpeg:
                   inputs:
@@ -243,6 +253,8 @@ spec:
                   streams:
                     Main: service_yard
                     Sub: service_yard_sub
+                objects:
+                  track: [person, car, dog, cat]
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"


### PR DESCRIPTION
Two changes, both safe to merge now. The YOLOv9 swap is **not** in this PR — see below for why.

## Detect only

The UDM already records every camera, so Frigate pulling six main streams around the clock duplicated that work. It was also actively breaking things: `living_room` and `family_room` (the two E1 Pro wifi cameras) can't sustain a 24/7 main-stream pull on top of Home Assistant's own connections, and were looping through RTSP timeouts → ffmpeg crash → watchdog restart. 117 and 78 errors in a 3-minute sample, while the four wired cameras were clean.

Each camera now has a single `detect` input on its sub stream, and `record.enabled: false`. Main streams stay declared in the built-in go2rtc so the UI still offers high-res live view — go2rtc only opens them while someone is watching, so nothing is held open.

Snapshots stay enabled, so alerts keep their stills and the MQTT/HA integration is unaffected. The tradeoff is no video playback inside Frigate: review items show a snapshot with nothing to scrub. `/media/frigate` on NFS is now snapshots-only, so it stays small.

## Per-camera object lists

The tracked-label list is a filter applied *after* inference, so a longer list costs no GPU time — only noise. Narrowing per camera is the cheap accuracy win:

| Camera | Tracked |
|---|---|
| entrance | person, car |
| backyard, backyard_pool, living_room, family_room | person, dog, cat |
| service_yard | person, car, dog, cat |

Global `track` drops to `person` as the baseline. `person` and `car` surface as *alerts*; everything else goes to the quieter *detections* bucket.

## Why YOLOv9 isn't here

It can't be a config-only change. Per the [docs](https://docs.frigate.video/configuration/object_detectors/#openvino-detector), no YOLOv9 model ships with Frigate and there's no auto-download — you export the ONNX yourself and place it at `/config/model_cache/`, which is the longhorn PVC. If this config merged before the file existed, Frigate would fail to start on a missing model path.

The export needs to happen first, then the config change lands as a follow-up. Sizing note for when it does: at 6.7 ms on SSDLite we're at roughly 20% detector utilization, so yolov9-`s` at 320 should fit with room to spare, and `t` is the fallback if inference time comes in higher than expected on Gen9.5.

## Validation

`kustomize build`, `helm template` against app-template 5.0.1, and a parse of the embedded Frigate config all pass; all six cameras render with one detect input and the intended label list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
