### PR TITLE
fix(frigate): make config.yml writable so the UI can persist changes

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -15,6 +15,21 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
+        initContainers:
+          init-config:
+            image:
+              repository: docker.io/mikefarah/yq
+              tag: 4.44.6
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                if [ -f /config/config.yml ]; then
+                  yq eval-all 'select(fileIndex==0) * select(fileIndex==1)' \
+                    /config/config.yml /config-src/config.yml > /config/config.yml.tmp
+                  mv /config/config.yml.tmp /config/config.yml
+                else
+                  cp /config-src/config.yml /config/config.yml
+                fi
         containers:
           app:
             image:
@@ -328,11 +343,15 @@ spec:
         existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /config
+      # Not mounted at /config/config.yml directly: the init container deep-merges
+      # this into the PVC's config.yml instead, so UI-only changes (e.g. custom
+      # classification models, which Frigate can only persist by writing to
+      # config.yml) survive pod restarts instead of being clobbered by git.
       config-file:
         type: configMap
         identifier: config
         globalMounts:
-          - path: /config/config.yml
+          - path: /config-src/config.yml
             subPath: config.yml
             readOnly: true
       media:


### PR DESCRIPTION
## Summary
- `config.yml` was bind-mounted read-only from the ConfigMap; anything Frigate needs to write back to it (e.g. a custom classification model created through Settings > Classification) silently failed, which is why `POST /api/classification/<name>/dataset/categorize` returned 404 on the wizard's Continue step.
- Added an `init-config` initContainer (`mikefarah/yq`) that deep-merges the git-sourced config onto the PVC's `config.yml` on every start (git wins on keys it declares, first boot falls back to a plain copy). UI-only additions not present in git (like a new classification model) now survive pod restarts instead of being clobbered.
- Moved the ConfigMap mount from `/config/config.yml` to `/config-src/config.yml` so it no longer occupies the writable path.

## Test plan
- [ ] `flux reconcile` / reloader restarts frigate, confirm `init-config` container logs show a clean merge (no yq errors)
- [ ] `kubectl exec` into frigate, `cat /config/config.yml`, confirm it matches git
- [ ] Retry the "New Classification" wizard in the UI end-to-end (name, camera crop, image categorization) and confirm no 404
- [ ] Restart the pod again and confirm the classification model created via UI is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUjc1UZ6ToMqiKc99vgbvq