### PR TITLE
fix(frigate): scope init container mounts, guard against config corruption

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -23,11 +23,9 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
-                # -s (not -f): a zero-byte config.yml must fall through to the
-                # plain copy below, or yq has nothing on fileIndex==0 to merge
-                # and silently emits nothing, clobbering config.yml with an
-                # empty file that every future boot then "merges" into more
-                # emptiness. Same guard on the merge's own output before mv.
+                # -s not -f: a zero-byte config.yml must fall through to the
+                # copy below, or yq merges against nothing and clobbers it
+                # with another empty file forever. Same guard on its output.
                 if [ -s /config/config.yml ] \
                   && yq eval-all 'select(fileIndex==0) * select(fileIndex==1)' \
                     /config/config.yml /config-src/config.yml > /config/config.yml.tmp \
@@ -349,10 +347,9 @@ spec:
         existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /config
-      # Not mounted at /config/config.yml directly: the init container deep-merges
-      # this into the PVC's config.yml instead, so UI-only changes (e.g. custom
-      # classification models, which Frigate can only persist by writing to
-      # config.yml) survive pod restarts instead of being clobbered by git.
+      # Not mounted at /config/config.yml: init-config merges this into the
+      # PVC's copy instead, so UI-only changes (e.g. classification models)
+      # survive restarts instead of being clobbered by the read-only git version.
       config-file:
         type: configMap
         identifier: config
@@ -360,8 +357,7 @@ spec:
           - path: /config-src/config.yml
             subPath: config.yml
             readOnly: true
-      # Scoped to the app container only: init-config doesn't touch media,
-      # models, cache or shm, and shouldn't wait on the NFS mount to start.
+      # Scoped to app only: init-config never touches media/models/cache/shm.
       media:
         existingClaim: frigate-media-nfs
         advancedMounts:

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -354,10 +354,14 @@ spec:
           - path: /config-src/config.yml
             subPath: config.yml
             readOnly: true
+      # Scoped to the app container only: init-config doesn't touch media,
+      # models, cache or shm, and shouldn't wait on the NFS mount to start.
       media:
         existingClaim: frigate-media-nfs
-        globalMounts:
-          - path: /media/frigate
+        advancedMounts:
+          frigate:
+            app:
+              - path: /media/frigate
       # Deliberately not under /config/model_cache: this mount is read-only and
       # Frigate writes its compiled OpenVINO blob into model_cache
       models:
@@ -366,18 +370,24 @@ spec:
           image:
             reference: ghcr.io/blackjid/yolov9-onnx:1.0.0
             pullPolicy: IfNotPresent
-        globalMounts:
-          - path: /models
-            readOnly: true
+        advancedMounts:
+          frigate:
+            app:
+              - path: /models
+                readOnly: true
       cache:
         type: emptyDir
         medium: Memory
         sizeLimit: 1Gi
-        globalMounts:
-          - path: /tmp/cache
+        advancedMounts:
+          frigate:
+            app:
+              - path: /tmp/cache
       shm:
         type: emptyDir
         medium: Memory
         sizeLimit: 256Mi
-        globalMounts:
-          - path: /dev/shm
+        advancedMounts:
+          frigate:
+            app:
+              - path: /dev/shm

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -23,9 +23,15 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
-                if [ -f /config/config.yml ]; then
-                  yq eval-all 'select(fileIndex==0) * select(fileIndex==1)' \
-                    /config/config.yml /config-src/config.yml > /config/config.yml.tmp
+                # -s (not -f): a zero-byte config.yml must fall through to the
+                # plain copy below, or yq has nothing on fileIndex==0 to merge
+                # and silently emits nothing, clobbering config.yml with an
+                # empty file that every future boot then "merges" into more
+                # emptiness. Same guard on the merge's own output before mv.
+                if [ -s /config/config.yml ] \
+                  && yq eval-all 'select(fileIndex==0) * select(fileIndex==1)' \
+                    /config/config.yml /config-src/config.yml > /config/config.yml.tmp \
+                  && [ -s /config/config.yml.tmp ]; then
                   mv /config/config.yml.tmp /config/config.yml
                 else
                   cp /config-src/config.yml /config/config.yml


### PR DESCRIPTION
## Summary
- `init-config` (added in #6343) only needs `config` and `config-file`; scoped `media`/`models`/`cache`/`shm` to the `app` container via `advancedMounts` instead of `globalMounts`.
- Fixed a self-corruption bug in the merge script: `[ -f ]` is true for a zero-byte file, so once `config.yml` went empty for any reason, every subsequent boot took the merge branch, `yq` had nothing on `fileIndex==0` to merge, emitted nothing, and the unconditional `mv` clobbered `config.yml` with another empty file — permanent, self-perpetuating corruption.

This second bug wasn't theoretical — it happened live while testing: `black-station.internal` (the NFS server backing `frigate-media-nfs`) went flaky and started timing out mounts across multiple pods (frigate, plex, qbittorrent), which caused enough pod churn that `config.yml` ended up empty on disk, and the app crash-looped with `AttributeError: 'NoneType' object has no attribute 'get'` in `get_listen_settings.py` / `get_ffmpeg_path.py` until manually restored via `kubectl exec ... cp`. Switched the guard to `[ -s ]` (exists AND non-empty) and added the same check on the merge's own output before `mv`, falling back to a plain copy of git's config in both cases instead of ever writing an empty file.

## Test plan
- [x] Reproduced the corruption locally with `sh -c` against fake `config.yml`/`config-src.yml` fixtures: empty existing file → falls back to copy; valid merge → git wins on conflicting keys, runtime-only keys survive; corrupt/unparseable existing file → falls back to copy instead of clobbering
- [x] Verified live: `init-config` mounts only `/config` + `/config-src/config.yml`; `app` still has media/models/cache/shm
- [ ] Watch a few more pod restarts to confirm no further corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUjc1UZ6ToMqiKc99vgbvq