### PR TITLE
feat(hermes): adopt ai/hermes into git, source secrets from 1Password, upgrade to v2026.8.27

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-secret
+    template:
+      data:
+        API_SERVER_KEY: "{{ .api_server_key }}"
+        HASS_TOKEN: "{{ .homeassistant_token }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -17,6 +17,9 @@ spec:
         TELEGRAM_BOT_TOKEN: "{{ .telegram_bot_token }}"
         TELEGRAM_ALLOWED_USERS: "{{ .telegram_allowed_users }}"
         TELEGRAM_HOME_CHANNEL: "{{ .telegram_home_channel }}"
+        HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "{{ .dashboard_username }}"
+        HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .dashboard_password }}"
+        HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .dashboard_session_secret }}"
   dataFrom:
     - extract:
         key: hermes

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       data:
         API_SERVER_KEY: "{{ .api_server_key }}"
         HASS_TOKEN: "{{ .homeassistant_token }}"
+        TELEGRAM_BOT_TOKEN: "{{ .telegram_bot_token }}"
+        TELEGRAM_ALLOWED_USERS: "{{ .telegram_allowed_users }}"
+        TELEGRAM_HOME_CHANNEL: "{{ .telegram_home_channel }}"
   dataFrom:
     - extract:
         key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,193 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hermes
+  interval: 1h
+  values:
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        pod:
+          automountServiceAccountToken: true
+        serviceAccount:
+          name: hermes
+        containers:
+          app:
+            image: &image
+              repository: nousresearch/hermes-agent
+              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+            command: ["hermes", "gateway", "run", "--no-supervise"]
+            env:
+              API_SERVER_ENABLED: "true"
+              API_SERVER_HOST: 0.0.0.0
+              API_SERVER_PORT: &gatewayPort 8642
+              HASS_URL: http://home-assistant.home.svc.cluster.local:8123
+              HERMES_HOME: &dataDir /opt/data
+              HOME: *dataDir
+              PATH: /opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              TZ: America/Santiago
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *gatewayPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *gatewayPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                cpu: 4
+                memory: 8Gi
+          dashboard:
+            image: *image
+            args: ["dashboard", "--host", "0.0.0.0", "--insecure"]
+            env:
+              GATEWAY_HEALTH_URL: http://localhost:8642
+              TZ: America/Santiago
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+    serviceAccount:
+      hermes: {}
+    rbac:
+      roles:
+        hermes-cluster:
+          type: ClusterRole
+          rules:
+            - apiGroups: [""]
+              resources:
+                - pods
+                - pods/log
+                - nodes
+                - services
+                - namespaces
+                - configmaps
+                - persistentvolumes
+                - persistentvolumeclaims
+                - endpoints
+                - serviceaccounts
+                - events
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["apps"]
+              resources: ["deployments", "daemonsets", "statefulsets", "replicasets", "controllerrevisions"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["batch"]
+              resources: ["jobs", "cronjobs"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["networking.k8s.io"]
+              resources: ["ingresses", "ingressclasses", "networkpolicies"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["storage.k8s.io"]
+              resources: ["storageclasses", "csinodes", "csidrivers", "volumeattachments"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["autoscaling"]
+              resources: ["horizontalpodautoscalers"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["policy"]
+              resources: ["poddisruptionbudgets"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["metrics.k8s.io"]
+              resources: ["nodes", "pods"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["helm.toolkit.fluxcd.io"]
+              resources: ["helmreleases"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+              resources: ["kustomizations"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["source.toolkit.fluxcd.io"]
+              resources: ["gitrepositories", "helmrepositories", "ocirepositories", "buckets", "helmcharts"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["external-secrets.io"]
+              resources: ["externalsecrets", "secretstores", "clustersecretstores"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["apps"]
+              resources: ["deployments", "daemonsets", "statefulsets"]
+              verbs: ["patch", "update"]
+            - apiGroups: ["apps"]
+              resources: ["deployments/scale", "statefulsets/scale"]
+              verbs: ["patch", "update"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["delete"]
+            - apiGroups: ["helm.toolkit.fluxcd.io"]
+              resources: ["helmreleases"]
+              verbs: ["patch"]
+            - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+              resources: ["kustomizations"]
+              verbs: ["patch"]
+      bindings:
+        hermes-cluster:
+          type: ClusterRoleBinding
+          roleRef:
+            kind: ClusterRole
+            identifier: hermes-cluster
+          subjects:
+            - kind: ServiceAccount
+              identifier: hermes
+    service:
+      app:
+        controller: hermes
+        ports:
+          dashboard:
+            port: &dashboardPort 9119
+          gateway:
+            port: *gatewayPort
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.blkh.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *dashboardPort
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: *dataDir
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           app:
             image: &image
               repository: nousresearch/hermes-agent
-              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+              tag: v2026.8.27@sha256:e0df6adebddf29b91112aefc999d4aaf6846c9eb544faca5672a16a13590ff79
             command: ["hermes", "gateway", "run", "--no-supervise"]
             env:
               API_SERVER_ENABLED: "true"
@@ -67,10 +67,13 @@ spec:
                 memory: 8Gi
           dashboard:
             image: *image
-            args: ["dashboard", "--host", "0.0.0.0", "--insecure"]
+            args: ["dashboard", "--host", "0.0.0.0"]
             env:
               GATEWAY_HEALTH_URL: http://localhost:8642
               TZ: America/Santiago
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/hermes/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes
+  namespace: ai
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes/app
+  postBuild:
+    substitute:
+      APP: hermes
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_PUID: "10000"
+      VOLSYNC_PGID: "10000"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./hermes/ks.yaml

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

`ai/hermes` was running in-cluster with **no Kustomization backing it** — the objects carried `kustomize.toolkit.fluxcd.io/name=hermes` labels pointing at a Kustomization that no longer existed, so nothing reconciled them. This brings it under Flux, moves the remaining secrets into 1Password, and upgrades to the latest release.

## 1. Adopt the orphaned deployment

Reconstructed from live cluster state, following the repo's `ks.yaml` + `app/` layout.

Adoption is seamless because the new Kustomization is named `hermes`/`ai`, matching the labels already on the live objects.

Verified:

| Check | Result |
|---|---|
| `helm template` of committed values vs live HelmRelease, chart 5.0.1 | **byte-identical** |
| Chart 5.0.1 → 5.1.0 (repo standard) | only the `helm.sh/chart` label, which is not in the pod template → **no restart** |
| volsync component vs live PVC / ReplicationSource / ReplicationDestination | **exact match** |
| `kubectl apply --server-side --dry-run=server` as `kustomize-controller` | no conflicts |

The stale `ai/hermes-configmap` is deliberately **not** adopted — it is mounted nowhere, and its contents have drifted from the live `/opt/data/config.yaml` that hermes manages itself on the PVC (`provider: codex` → `openai-codex`, `gpt-5-codex` → `gpt-5.4-mini`). It can be deleted manually.

## 2. Secrets from 1Password

`/opt/data/.env` on the PVC is loaded with `override=True` (`HERMES_HOME=/opt/data`, so it resolves as the *user* env file), which **shadows every env var the pod receives from `hermes-secret`**. The 1Password `HASS_TOKEN` was effectively dead.

Telegram credentials now come from the 1Password `hermes` item so the ExternalSecret is the single source and the PVC `.env` can be removed.

## 3. Upgrade to v2026.8.27

Not a drop-in tag bump. The June 2026 hardening turned `hermes dashboard --insecure` into a **no-op** — a non-loopback bind now always requires an auth provider. The dashboard binds `0.0.0.0` and is published on `hermes.blkh.dev`, so the upgrade alone would have locked the UI out.

Dashboard basic auth is therefore configured from the 1Password-backed secret rather than `dashboard.basic_auth` in `config.yaml`. The plugin follows an env-wins convention (`plugins/dashboard_auth/basic/__init__.py:442`), so credentials stay out of the PVC. This also closes the current gap where the dashboard serves API keys **unauthenticated** on the internal network.

Verified against the new image: newest tag, digest confirmed from the registry, `linux/amd64` present, and `gateway run --no-supervise` still exists. The dead `--insecure` flag is dropped and the dashboard container gets the `envFrom` it previously lacked.

## Post-merge steps

Once Flux reconciles:

```sh
kubectl get externalsecret -n ai hermes          # expect SecretSynced
kubectl exec -n ai deploy/hermes -c app -- rm /opt/data/.env
kubectl rollout restart -n ai deploy/hermes
kubectl delete cm -n ai hermes-configmap
```

The `rm` is what actually hands control to 1Password — until then `.env` keeps overriding.

Then blank `api_server.key` in the UI so `API_SERVER_KEY` from the secret takes effect (`config.yaml` wins over env for that one specifically — `gateway/platforms/api_server.py:708`).

## Notes

- This jumps ~3 months and `config.yaml` is at `_config_version: 27`, so hermes will likely migrate the schema on the PVC on first start. Last volsync sync is the restore point.
- Worth rotating the API key and Telegram bot token — both sat in cleartext on a PVC that replicates to the NFS kopia repo, so they are in backup history.
- `ai/hass-mcp` remains unmanaged, and hermes calls it at runtime (`mcp_servers.hass.url`). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SexyqvVJ7TCK9KTNhQya3G