### PR TITLE
feat(hermes): add gmail mcp oauth client to the 1Password-backed secret

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -20,6 +20,8 @@ spec:
         HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "{{ .dashboard_username }}"
         HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .dashboard_password }}"
         HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .dashboard_session_secret }}"
+        GMAIL_MCP_CLIENT_ID: "{{ .gmail_mcp_client_id }}"
+        GMAIL_MCP_CLIENT_SECRET: "{{ .gmail_mcp_client_secret }}"
   dataFrom:
     - extract:
         key: hermes


### PR DESCRIPTION
## Why

Google does not support RFC 7591 dynamic client registration, so hermes cannot auto-register an MCP OAuth client and instead asks for a pre-registered one:

> Some providers (e.g. Google Drive, Atlassian) do not support automatic client registration. For those you must create an OAuth client yourself and add its credentials to config.yaml

Taking the literal advice would put a Google client secret in `/opt/data/config.yaml` on the PVC — which replicates to the NFS kopia repo in cleartext, the same problem `api_server.key` already has.

## Instead

Expose the credentials as env vars from the existing 1Password `hermes` item and reference them from config with `${VAR}` placeholders. `_interpolate_env_vars` resolves those **recursively** through an MCP server's config, nested `oauth` block included (`tools/mcp_tool.py:5649`), so the secret never lands on the volume.

Verified both fields resolve from 1Password before merging; `GMAIL_MCP_CLIENT_ID` has the expected `…apps.googleusercontent.com` shape.

## Config to add (UI or config.yaml, not this repo)

```yaml
mcp_servers:
  gmail:
    url: <gmail mcp url>
    auth: oauth
    oauth:
      client_id: "${GMAIL_MCP_CLIENT_ID}"
      client_secret: "${GMAIL_MCP_CLIENT_SECRET}"
```

Then `hermes mcp login gmail`.

Note: unset variables keep the **literal placeholder** rather than erroring, so a typo surfaces as a confusing auth failure rather than a clear one — worth checking the interpolated value if login misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SexyqvVJ7TCK9KTNhQya3G