### PR TITLE
feat(ha-mcp): adopt deployment into git

### DIFF
--- a/kubernetes/apps/ai/hass-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hass-mcp/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hass-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hass-mcp-secret
+    template:
+      data:
+        HA_TOKEN: "{{ .hass_token }}"
+        HOMEASSISTANT_TOKEN: "{{ .hass_token }}"
+  dataFrom:
+    - extract:
+        key: home-assistant

--- a/kubernetes/apps/ai/hass-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hass-mcp/app/helmrelease.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hass-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hass-mcp
+  interval: 1h
+  values:
+    controllers:
+      hass-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/homeassistant-ai/ha-mcp
+              tag: 8.3.0@sha256:38b3a0b6b6b69d3fd074f958fbf9653ae2d50c8727b4c0dcde640cfa3a638176
+            command: ["ha-mcp-web"]
+            env:
+              HOMEASSISTANT_URL: http://home-assistant.home.svc.cluster.local:8123
+              TZ: America/Santiago
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8086
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: hass-mcp
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.blkh.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: longhorn
+        retain: true
+        globalMounts:
+          - path: /home/mcpuser/.ha-mcp
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/hass-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hass-mcp/app/kustomization.yaml
@@ -2,12 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  - ./hass-mcp/ks.yaml
-  - ./hermes/ks.yaml
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/hass-mcp/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hass-mcp/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hass-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hass-mcp/ks.yaml
+++ b/kubernetes/apps/ai/hass-mcp/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hass-mcp
+  namespace: ai
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/hass-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false


### PR DESCRIPTION
## Summary

- re-adopt the orphaned hass-mcp release under Flux in the ai namespace
- move the workload to homeassistant-ai/ha-mcp 8.3.0 with the current HTTP command and environment contract
- retain the existing hostname and release names for an in-place migration
- add hardened runtime settings and a retained 1 GiB Longhorn data volume

## Validation

- app-level Kustomize render
- Flux local render
- Helm app-template 5.1.0 render
- kubeconform
- server-side dry-run using the Flux field manager
- git diff --check