### PR TITLE
chore(ha-mcp): remove legacy token alias

### DIFF
--- a/kubernetes/apps/ai/hass-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hass-mcp/app/externalsecret.yaml
@@ -12,7 +12,6 @@ spec:
     name: hass-mcp-secret
     template:
       data:
-        HA_TOKEN: "{{ .hass_token }}"
         HOMEASSISTANT_TOKEN: "{{ .hass_token }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
## Summary

Remove the old HA_TOKEN secret key after the successful homeassistant-ai/ha-mcp rollout. The running 8.3.0 deployment uses HOMEASSISTANT_TOKEN.

## Validation

- Kustomize render
- Flux local render
- server-side dry-run using the Flux field manager
- end-to-end ha_get_overview call passed before cleanup