### PR TITLE
fix(longhorn): drop v1.11.0-hotfix-1 image pins

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     preUpgradeChecker:
       jobEnabled: false
-      upgradeVersionCheck: false
-    image:
-      longhorn:
-        instanceManager:
-          tag: v1.11.0-hotfix-1
-        manager:
-          tag: v1.11.0-hotfix-1
     persistence:
       defaultDataLocality: best-effort
       recurringJobSelector:


### PR DESCRIPTION
## What

Removes the `image.longhorn.manager.tag` / `image.longhorn.instanceManager.tag` pins on `v1.11.0-hotfix-1` and the `preUpgradeChecker.upgradeVersionCheck: false` override that was added alongside them.

## Why

The pins landed in #5322 (2026-02-10) when the chart was on **1.11.0**. `upgradeVersionCheck` was disabled at the same time so the deliberate mismatch would not trip Longhorn's own guardrail. Neither was removed when the chart moved **1.11.2 → 1.12.0** on 2026-07-21, so for ~6 weeks the cluster has run a split-version Longhorn:

| Component | Version |
|---|---|
| chart | 1.12.1 |
| longhorn-manager | **v1.11.0-hotfix-1** |
| longhorn-instance-manager | **v1.11.0-hotfix-1** |
| longhorn-engine | v1.12.1 |
| share-manager / UI | v1.12.1 |

All 68 volumes already run engine `v1.12.1`.

It works today — `EngineImage ei-493e04e7` reports `cliAPIVersion: 12` against `cliAPIMinVersion: 8` and the 1.11 manager marks it `incompatible: false` — but it is the unsupported direction. Longhorn expects manager ≥ engine: a 1.11 manager is driving 1.12 CRDs, 1.12 chart-rendered DaemonSet specs, and serving a 1.11 admission/conversion webhook for 1.12 objects. Upstream does not test that pairing.

Left alone it gets worse on its own: Renovate keeps bumping the chart while the pins stay frozen. At chart 1.13 the gap becomes 1.11 → 1.13, a skipped minor, which Longhorn does not support. Fixing it now is a single-minor step.

## Effect on apply

- `longhorn-manager` DaemonSet rolls (3 pods) to v1.12.1.
- New v1.12.1 instance-manager pods are created; engine and replica processes for currently-attached volumes keep running in the old v1.11 IM pods until those volumes detach. Old IM pods are cleaned up once empty.
- V1 volumes stay attached — no detach required. Engine images are already at 1.12.1, so no engine upgrade follows.
- `upgradeVersionCheck` returns to the chart default (`true`), so a future pin/chart drift fails loudly instead of silently. `preUpgradeChecker.jobEnabled` stays `false`, which the chart recommends for GitOps installs.

The `v1.11.0-hotfix-1` fix is a respin of 1.11.0 and is carried forward in 1.11.1+ and 1.12.x, so nothing is lost by dropping the pin.

## Before merging

Land this once the cluster is quiet. All three nodes are on Talos v1.14.0 and Ready as of now; one volume (`pvc-39124b02`) is still rebuilding from today's reboots — let it reach `healthy` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeHrud3wRUauG8NREKbAzS