### PR TITLE
fix(longhorn): require replicas on distinct nodes

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
     defaultSettings:
       defaultDataPath: "/var/mnt/longhorn"
       replicaDiskSoftAntiAffinity: true
-      replicaSoftAntiAffinity: "true"
+      replicaSoftAntiAffinity: "false"
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort
       defaultLonghornStaticStorageClass: longhorn


### PR DESCRIPTION
## What

`defaultSettings.replicaSoftAntiAffinity: "true"` → `"false"`. One line.

## Why

With soft anti-affinity, once a node is down longer than `replicaReplenishmentWaitInterval` (3600s), Longhorn replenishes the missing replica onto a node that **already holds one**. The volume goes back to `robustness: healthy` without the absent node — so tuppr's gate:

```yaml
expr: status.state != "attached" || status.robustness == "healthy"
```

passes while two of three replicas sit on one machine. tuppr then reboots the next node, which can be that machine, taking the volume to 1 of 3.

That is not hypothetical — it is what today's Talos 1.14 upgrade did. k8s-1 was unavailable ~1h30m, past the 1h replenishment wait. Result: **20 volumes with colocated replicas**, and `pvc-940a7f83` running on a **single** RW replica. It also left 40 surplus replicas that deadlocked every rebuild slot on k8s-1 and needed manual cleanup.

## What changes

With 3 nodes and 3 replicas, hard anti-affinity means `healthy` can only be satisfied by one replica per node. So:

- While a node is upgrading, its volumes sit `degraded` (2/3) and Longhorn has nowhere to replenish — no doubling-up, no surplus replicas.
- When the node returns and rebuilds its replica, volumes go `healthy`.
- Only then does tuppr's pre-node health check pass and the next node is drained.

`healthy` now *implies* the rebooted node rebuilt its replica. The gate means what it looks like it means.

No tuppr change is needed: `parallelism` already defaults to `1` (the live CR reads `1`) and `healthChecks` are defined as running "before each node upgrade". The existing 2h timeout is ample — `fast-replica-rebuild-enabled` is `true`, and after today's cleanup ~30 replicas resynced in about 10 minutes.

## Trade-off

A genuinely dead node has nowhere to replenish to, so volumes stay degraded until you add a replacement node or drop `defaultReplicaCount`. Automatic self-healing on real node loss is traded for correct behaviour during planned maintenance. On a 3-node cluster where every upgrade is planned, that's the better side of the trade — but it is a real loss, and worth knowing before the next node dies.

The lighter alternative, if you'd rather keep self-healing, is raising `replicaReplenishmentWaitInterval` past worst-case node maintenance instead. That narrows the window without closing it.

## Rollout

All 68 volumes carry `spec.replicaSoftAntiAffinity: ignored`, so they inherit the global setting the moment it reconciles — no per-volume edits, no restarts. Current state is 0 colocated volumes and 0 degraded, so nothing has to be unwound on apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeHrud3wRUauG8NREKbAzS