### PR TITLE
feat(talos): migrate machine config to 1.14 multi-document kinds

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -9,89 +9,7 @@ machine:
   features:
     apidCheckExtKeyUsage: true
     diskQuotaSupport: true
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: true # Requires Cilium socketLB features
-      resolveMemberNames: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    {% if ENV.IS_CONTROLLER %}
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedKubernetesNamespaces:
-        - actions-runner-system
-        - system-upgrade
-      allowedRoles:
-        - os:admin
-    {% endif %}
     rbac: true
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          device_ownership_from_security_context = true
-    - op: overwrite
-      path: /etc/nfsmount.conf
-      permissions: 0o644
-      content: |
-        [ NFSMount_Global_Options ]
-        nfsvers=3
-        hard=True
-        nolock=True
-        nconnect=8
-        noatime=True
-        rsize=1048576
-        wsize=1048576
-  install:
-    disk: /dev/nvme0n1
-    image: factory.talos.dev/metal-installer/70e64fe909966c58a9de15d74b7cb61f453cec21cca9eccc8de133f6a72f72b8:v1.14.0
-    wipe: false
-  kernel:
-    modules:
-      - name: nbd
-  kubelet:
-    defaultRuntimeSeccompProfileEnabled: true
-    disableManifestsDirectory: true
-    extraConfig:
-      serializeImagePulls: false
-    extraMounts:
-      - destination: /var/mnt/longhorn
-        type: bind
-        source: /var/mnt/longhorn
-        options: ["bind", "rshared", "rw"]
-    image: ghcr.io/siderolabs/kubelet:v1.36.4
-    nodeIP:
-      validSubnets:
-        - 192.168.42.0/24
-  nodeLabels:
-    node.kubernetes.io/gpu: "true"
-    topology.kubernetes.io/region: main
-  sysctls:
-    fs.inotify.max_user_instances: "8192"
-    fs.inotify.max_user_watches: "1048576"
-    net.core.default_qdisc: fq
-    net.core.rmem_max: "67108864"
-    net.core.wmem_max: "67108864"
-    net.ipv4.neigh.default.gc_thresh1: "4096"
-    net.ipv4.neigh.default.gc_thresh2: "8192"
-    net.ipv4.neigh.default.gc_thresh3: "16384"
-    net.ipv4.ping_group_range: 0 2147483647
-    net.ipv4.tcp_congestion_control: bbr
-    net.ipv4.tcp_fastopen: "3"
-    net.ipv4.tcp_mtu_probing: "1"
-    net.ipv4.tcp_notsent_lowat: "131072"
-    net.ipv4.tcp_rmem: 4096 87380 33554432
-    net.ipv4.tcp_slow_start_after_idle: "0"
-    net.ipv4.tcp_window_scaling: "1"
-    net.ipv4.tcp_wmem: 4096 65536 33554432
-    sunrpc.tcp_max_slot_table_entries: "128"
-    sunrpc.tcp_slot_table_entries: "128"
-    user.max_user_namespaces: "11255"
-    vm.nr_hugepages: "1024"
   token: op://kubernetes/talos/MACHINE_TOKEN
 cluster:
   ca:
@@ -102,49 +20,11 @@ cluster:
   clusterName: main
   controlPlane:
     endpoint: https://k8s.internal:6443
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  id: op://kubernetes/talos/CLUSTER_ID
-  network:
-    cni:
-      name: none
-    dnsDomain: cluster.local
-    podSubnets:
-      - 10.42.0.0/16
-    serviceSubnets:
-      - 10.43.0.0/16
-  secret: op://kubernetes/talos/CLUSTER_SECRET
   token: op://kubernetes/talos/CLUSTER_TOKEN
   {% if ENV.IS_CONTROLLER %}
   aggregatorCA:
     crt: op://kubernetes/talos/CLUSTER_AGGREGATORCA_CRT
     key: op://kubernetes/talos/CLUSTER_AGGREGATORCA_KEY
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    auditPolicy:
-      apiVersion: audit.k8s.io/v1
-      kind: Policy
-      rules:
-        - level: Metadata
-    certSANs:
-      - k8s.internal
-    disablePodSecurityPolicy: true
-    extraArgs:
-      enable-aggregator-routing: "true"
-      feature-gates: HPAScaleToZero=true
-    image: registry.k8s.io/kube-apiserver:v1.36.4
-  controllerManager:
-    extraArgs:
-      bind-address: 0.0.0.0
-      feature-gates: HPAScaleToZero=true
-    image: registry.k8s.io/kube-controller-manager:v1.36.4
-  coreDNS:
-    disabled: true
   etcd:
     advertisedSubnets:
       - 192.168.42.0/24
@@ -153,31 +33,6 @@ cluster:
       key: op://kubernetes/talos/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-  proxy:
-    disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.4
-  scheduler:
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-    extraArgs:
-      bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-scheduler:v1.36.4
-  secretboxEncryptionSecret: op://kubernetes/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET
   serviceAccount:
     key: op://kubernetes/talos/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
@@ -203,6 +58,32 @@ parent: bond0
 mtu: 1500
 ---
 apiVersion: v1alpha1
+kind: ResolverConfig
+hostDNS:
+  enabled: true
+  forwardKubeDNSToHost: true
+  resolveMemberNames: true
+---
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: https://discovery.talos.dev/
+---
+apiVersion: v1alpha1
+kind: DiscoveryIdentityConfig
+clusterID: op://kubernetes/talos/CLUSTER_ID
+clusterSecret: op://kubernetes/talos/CLUSTER_SECRET
+---
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+installer:
+  image: factory.talos.dev/metal-installer/70e64fe909966c58a9de15d74b7cb61f453cec21cca9eccc8de133f6a72f72b8:v1.14.0
+provisioning:
+  diskSelector:
+    match: disk.dev_path == "/dev/nvme0n1"
+  wipe: false
+---
+apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
@@ -214,3 +95,171 @@ apiVersion: v1alpha1
 kind: WatchdogTimerConfig
 device: /dev/watchdog0
 timeout: 10m
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nbd
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_instances: "8192"
+  fs.inotify.max_user_watches: "1048576"
+  net.core.default_qdisc: fq
+  net.core.rmem_max: "67108864"
+  net.core.wmem_max: "67108864"
+  net.ipv4.neigh.default.gc_thresh1: "4096"
+  net.ipv4.neigh.default.gc_thresh2: "8192"
+  net.ipv4.neigh.default.gc_thresh3: "16384"
+  net.ipv4.ping_group_range: 0 2147483647
+  net.ipv4.tcp_congestion_control: bbr
+  net.ipv4.tcp_fastopen: "3"
+  net.ipv4.tcp_mtu_probing: "1"
+  net.ipv4.tcp_notsent_lowat: "131072"
+  net.ipv4.tcp_rmem: 4096 87380 33554432
+  net.ipv4.tcp_slow_start_after_idle: "0"
+  net.ipv4.tcp_window_scaling: "1"
+  net.ipv4.tcp_wmem: 4096 65536 33554432
+  sunrpc.tcp_max_slot_table_entries: "128"
+  sunrpc.tcp_slot_table_entries: "128"
+  user.max_user_namespaces: "11255"
+  vm.nr_hugepages: "1024"
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: nfsmount.conf
+mode: 0o644
+contents: |
+  [ NFSMount_Global_Options ]
+  nfsvers=3
+  hard=True
+  nolock=True
+  nconnect=8
+  noatime=True
+  rsize=1048576
+  wsize=1048576
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: containerd
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = true
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets:
+    - 192.168.42.0/24
+labels:
+  node-role.kubernetes.io/control-plane: ""
+  node.kubernetes.io/gpu: "true"
+  topology.kubernetes.io/region: main
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+config:
+  serializeImagePulls: false
+defaultRuntimeSeccompProfileEnabled: true
+image: ghcr.io/siderolabs/kubelet:v1.36.4
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets:
+  - 10.42.0.0/16
+serviceSubnets:
+  - 10.43.0.0/16
+---
+apiVersion: v1alpha1
+kind: KubePrismConfig
+port: 7445
+{% if ENV.IS_CONTROLLER %}
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+certExtraSANs:
+  - k8s.internal
+extraArgs:
+  enable-aggregator-routing: "true"
+  feature-gates: HPAScaleToZero=true
+image: registry.k8s.io/kube-apiserver:v1.36.4
+---
+apiVersion: v1alpha1
+kind: KubeAuditPolicyConfig
+configuration:
+  apiVersion: audit.k8s.io/v1
+  kind: Policy
+  rules:
+    - level: Metadata
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: node
+type: Node
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: rbac
+type: RBAC
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+extraArgs:
+  bind-address: 0.0.0.0
+  feature-gates: HPAScaleToZero=true
+image: registry.k8s.io/kube-controller-manager:v1.36.4
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+apiVersion: v1alpha1
+kind: KubeEtcdEncryptionConfig
+config:
+  resources:
+    - providers:
+        - secretbox:
+            keys:
+              - name: key2
+                secret: op://kubernetes/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET
+        - identity: {}
+      resources:
+        - secrets
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+image: registry.k8s.io/kube-proxy:v1.36.4
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+extraArgs:
+  bind-address: 0.0.0.0
+image: registry.k8s.io/kube-scheduler:v1.36.4
+---
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:admin
+allowedKubernetesNamespaces:
+  - actions-runner-system
+  - system-upgrade
+{% endif %}

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -196,6 +196,17 @@ configuration:
     - level: Metadata
 ---
 apiVersion: v1alpha1
+kind: KubeAuthenticationConfig
+configuration:
+  anonymous:
+    conditions:
+      - path: /livez
+      - path: /readyz
+      - path: /healthz
+    enabled: true
+  jwt: []
+---
+apiVersion: v1alpha1
 kind: KubeAuthorizerConfig
 name: node
 type: Node

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -60,4 +60,4 @@ machine-controller node:
 
 [private]
 machine-image:
-    just template "{{ talos_dir }}/machineconfig.yaml.j2" | yq -e 'select(.machine) | .machine.install.image'
+    just template "{{ talos_dir }}/machineconfig.yaml.j2" | yq -e 'select(.kind == "UnattendedInstallConfig") | .installer.image'

--- a/talos/nodes/k8s-0.yaml.j2
+++ b/talos/nodes/k8s-0.yaml.j2
@@ -1,12 +1,15 @@
 ---
 machine:
-  nodeLabels:
-    topology.kubernetes.io/zone: m
   type: controlplane
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig
 hostname: k8s-0
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
 kind: LinkAliasConfig

--- a/talos/nodes/k8s-1.yaml.j2
+++ b/talos/nodes/k8s-1.yaml.j2
@@ -1,12 +1,15 @@
 ---
 machine:
-  nodeLabels:
-    topology.kubernetes.io/zone: m
   type: controlplane
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig
 hostname: k8s-1
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
 kind: LinkAliasConfig

--- a/talos/nodes/k8s-2.yaml.j2
+++ b/talos/nodes/k8s-2.yaml.j2
@@ -1,12 +1,15 @@
 ---
 machine:
-  nodeLabels:
-    topology.kubernetes.io/zone: m
   type: controlplane
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig
 hostname: k8s-2
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
 kind: LinkAliasConfig


### PR DESCRIPTION
## What

Moves `talos/machineconfig.yaml.j2` off the deprecated v1alpha1 fields onto Talos 1.14's dedicated config documents, plus the matching node-patch and `mod.just` changes.

Still v1alpha1: `machine.{ca,features,token,type}`, `cluster.{ca,clusterName,controlPlane,token}` and the controlplane-only `aggregatorCA` / `etcd` / `serviceAccount` — the same split onedr0p settled on.

Requires #6383 (talosctl 1.14); a 1.13 client rejects these outright with `"KubeNodeConfig" "v1alpha1": not registered`.

## Two defaults that silently disappear

Adopting `KubeAPIServerConfig` turns off two things the v1alpha1 path did implicitly. **Both are load-bearing**, and the first one took down an apiserver during rollout before it was added.

**`KubeAuthenticationConfig` is mandatory, not optional.**

```go
func (s *KubeAPIServerConfigV1Alpha1) UseAuthenticationConfig() bool { return true }
```

Unconditional — so the apiserver is always started with `--authentication-config`. Without the document, `ControlPlaneAuthenticationController` never creates the resource, Talos renders the file as `{}`, and the apiserver refuses to boot:

```
failed to load authentication configuration from file
".../authentication-config.yaml": Object 'Kind' is missing in '{}'
```

The v1alpha1 path passed `--anonymous-auth=false` instead and never wrote the file, so this only appears after migrating.

Anonymous is scoped to the health endpoints rather than disabled outright, because `KubeAPIServerConfig` **also flips `startupProbesEnabled` false → true**:

```
k8s-0 (migrated):  startupProbe /livez, livenessProbe /livez, readinessProbe /readyz
k8s-1 (pre-apply): no probes at all
```

Those probes are unauthenticated, so `anonymous: {enabled: false}` would 401 every one of them and crash-loop the pod. `apiVersion`/`kind` are injected by the controller and are deliberately absent from `configuration:`.

**`KubeAuthorizerConfig` node/rbac must be declared.** `InjectDefaultAuthorizers()` returns `false` for the new document where the v1alpha1 shim returns `true`. Without them the apiserver gets **zero** authorizers. The nodes' live `authorization-config.yaml` reads `node/Node` + `rbac/RBAC`.

## Three removals that are not one-for-one

**`.machine.kubelet.extraMounts` is dropped — no equivalent exists.** The field is marked `Deprecated: removed in multi-doc config` and `KubeletConfig.ExtraMounts()` returns `nil`. Not needed: the Longhorn data path is the `longhorn` `UserVolumeConfig` at `/var/mnt/longhorn` with a matching `defaultDataPath`, which is what Talos 1.14's own Longhorn CI switched to when it deleted the same patch.

**`.cluster.network.cni.name: none` is dropped.** With the section absent, `K8sFlannelCNIConfig()` returns nil — the source comment is explicit: *"if the section is missing, assume it's not set (multi-doc should provide it)"*. No Flannel; Cilium untouched.

**`.cluster.disablePodSecurityPolicy` is dropped** — PSP is gone in 1.36.

Also: `KubeNodeConfig` now sets `node-role.kubernetes.io/control-plane` explicitly (the v1alpha1 bridge injected it), `allowSchedulingOnControlPlanes: true` becomes the absence of a taint, and `disableManifestsDirectory` is dropped because `KubeletConfig` hardcodes it to `true`.

`KubeEtcdEncryptionConfig` keeps key name **`key2`**, read off the running apiserver's `encryptionconfig.yaml` — a different name would make existing encrypted secrets unreadable.

## Verification

Applied to all three nodes, plus cold reboots of k8s-0 and k8s-2:

| | |
|---|---|
| validate | all 3 nodes pass `talosctl validate -m metal`, no deprecation warnings |
| dry-run | every removed v1alpha1 key lands in a corresponding document |
| **etcd decryption** | secrets read fine through a migrated apiserver — `key2` still decrypts |
| control plane | all 9 pods `1/1`; 0 restarts on the two rebooted nodes, so probes are not flapping |
| boot-generated | after reboot: `nbd` loaded, sysctls (`bbr`, `nr_hugepages`, `max_user_namespaces`) correct — proving the documents generate them from cold, not leftovers |
| mounts | `EPHEMERAL`, `u-local-hostpath`, `u-longhorn` all mount, including k8s-2's `/dev/sda1`/`/dev/sda2` layout |
| labels | all four labels on all three nodes, no taints |
| **Longhorn without `extraMounts`** | replica counts match across nodes; 0 colocated volumes |

## Still untested

`UnattendedInstallConfig`. A reboot never invokes the installer — only an upgrade does. The next Talos upgrade is the first real exercise of `diskSelector.match: disk.dev_path == "/dev/nvme0n1"`. `SystemDisk` resolves to `nvme0n1`, so it should match, but it is unproven until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeHrud3wRUauG8NREKbAzS