### PR TITLE
feat(kopiur): distribute repo credentials to the remaining namespaces

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: ai
 
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secret
 
 resources:
   - ./namespace.yaml

--- a/kubernetes/apps/development/kustomization.yaml
+++ b/kubernetes/apps/development/kustomization.yaml
@@ -4,6 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: development
 
+components:
+  - ../../components/kopiur/secret
+
 resources:
   - ./namespace.yaml
   - ./board-game-collection/ks.yaml

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: home
 
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secret
 
 resources:
   - ./namespace.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: media
 
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secret
 
 resources:
   - ./namespace.yaml


### PR DESCRIPTION
Adds `components/kopiur/secret` to `ai`, `development`, `home` and `media`, so the `kopiur-repository-secret` ExternalSecret exists in every namespace that still has volsync-backed apps. `default` and `kopiur-system` already had it from #6152.

No app references a kopiur component in these namespaces yet, so this only creates four ExternalSecrets and changes no backup behaviour. It is a prerequisite for the per-namespace backup-phase changes that follow: the kopiur mover cannot read the repository password without it.

`development` had no `components:` block at all, so one is added.

`kustomize build` passes for all five app namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)