### PR TITLE
feat(hermes): back up with kopiur alongside volsync

### DIFF
--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -7,8 +7,11 @@ metadata:
   namespace: ai
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,9 @@ spec:
   postBuild:
     substitute:
       APP: hermes
+      KOPIUR_CAPACITY: 10Gi
+      KOPIUR_PUID: "10000"
+      KOPIUR_PGID: "10000"
       VOLSYNC_CAPACITY: 10Gi
       VOLSYNC_PUID: "10000"
       VOLSYNC_PGID: "10000"


### PR DESCRIPTION
Backup phase of hermes' volsync → kopiur migration, mirroring what #6148 did for actual: adds `components/kopiur/backup` (SnapshotPolicy + SnapshotSchedule, no PVC/Restore) and the `kopiur-repository` dependency, leaving the existing volsync setup fully in place. The two never touch each other's resources — kopiur only reads the source PVC — so this is reversible by dropping the component again.

`KOPIUR_PUID`/`KOPIUR_PGID` mirror hermes' `VOLSYNC_PUID`/`VOLSYNC_PGID` (10000); hermes is the only app that overrides them.

### New lineage, not a continuation

Snapshots land under `hermes@ai:/pvc/hermes`, while volsync writes `hermes@ai:/data`. `kubectl kopiur migrate volsync -n ai --name hermes --repository nas --repository-kind cluster-repository` (run read-only) would pin `spec.identity` plus `sources[0].sourcePathOverride` to bridge the two, but onedr0p's component does neither, and actual has been running this way since #6155 — its adoption scan matched 0 of 419 repository snapshots. Following the upstream convention here.

The consequence: hermes' volsync history is **not** a fallback once the cutover deletes the PVC — that restore can only come from a kopiur-lineage snapshot. So the cutover to `components/kopiur/restore` waits for green scheduled snapshots and a restore drill against a scratch PVC, as actual's did.

Prerequisite #6412 is merged, so `kopiur-repository-secret` already exists in `ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)