### PR TITLE
feat(default): back up atuin, n8n, obsidian-couchdb and thelounge with kopiur

### DIFF
--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: atuin
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: atuin
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/n8n/ks.yaml
+++ b/kubernetes/apps/default/n8n/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: n8n
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: n8n
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/obsidian-couchdb/ks.yaml
+++ b/kubernetes/apps/default/obsidian-couchdb/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: obsidian-couchdb
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: obsidian-couchdb
+      KOPIUR_CAPACITY: 30Gi
       VOLSYNC_CAPACITY: 30Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: thelounge
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h


### PR DESCRIPTION
Backup phase for the four remaining volsync apps in the `default` namespace, same shape as #6148 for actual: `components/kopiur/backup` plus the `kopiur-repository` dependency, with volsync left running untouched beside it.

`KOPIUR_CAPACITY` mirrors each app's `VOLSYNC_CAPACITY`. thelounge sets neither and takes the component default of 5Gi, as it does today under volsync.

Note that `KOPIUR_CAPACITY` also sizes the mover cache PVC, so obsidian-couchdb provisions a 30Gi `longhorn-cache` volume per run. Volsync couples `cacheCapacity` to the same variable, so this is not a regression.

### New lineage, not a continuation

Snapshots land under `<app>@default:/pvc/<app>`, while volsync writes `<app>@default:/data`. onedr0p's component pins neither `spec.identity` nor `sources[0].sourcePathOverride`, and actual has been running this way since #6155 — its adoption scan matched 0 of 419 repository snapshots. Following the upstream convention.

The consequence: the volsync history is **not** a fallback once a cutover deletes a PVC — that restore can only come from a kopiur-lineage snapshot. So each cutover to `components/kopiur/restore` waits for green scheduled snapshots and a restore drill against a scratch PVC, as actual's did, and lands per app rather than as one batch.

Prerequisite #6412 is merged; `default` already had the secret component from #6152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)