### PR TITLE
feat(home): back up esphome, frigate, home-assistant, matter-server, zigbee2mqtt and zwave with kopiur

### DIFF
--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -7,8 +7,11 @@ metadata:
   namespace: home
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: esphome
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -7,12 +7,15 @@ metadata:
   namespace: home
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: csi-driver-nfs
       namespace: kube-system
     - name: intel-gpu-resource-driver
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
     - name: mosquitto
@@ -22,6 +25,7 @@ spec:
   postBuild:
     substitute:
       APP: frigate
+      KOPIUR_CAPACITY: 10Gi
       VOLSYNC_CAPACITY: 10Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -7,10 +7,13 @@ metadata:
   namespace: home
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: multus-networks
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -18,6 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: home-assistant
+      KOPIUR_CAPACITY: 10Gi
       VOLSYNC_CAPACITY: 10Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -7,8 +7,11 @@ metadata:
   namespace: home
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: matter-server
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: zigbee2mqtt
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
     - name: mosquitto
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: zigbee2mqtt
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zwave/ks.yaml
+++ b/kubernetes/apps/home/zwave/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: zwave
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: zwave
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
Backup phase for the six volsync apps in the `home` namespace, same shape as #6413 / #6414: `components/kopiur/backup` plus the `kopiur-repository` dependency, with volsync left running untouched beside it.

`KOPIUR_CAPACITY` mirrors each app's `VOLSYNC_CAPACITY`. Since that variable also sizes the mover cache PVC, frigate and home-assistant each provision a 10Gi `longhorn-cache` volume per run; volsync couples `cacheCapacity` to the same variable, so this is not a regression.

### New lineage, not a continuation

Snapshots land under `<app>@home:/pvc/<app>` rather than continuing volsync's `<app>@home:/data`, following onedr0p's component (see #6413 for the full rationale). The volsync history is therefore **not** a fallback once a cutover deletes a PVC.

That matters more here than elsewhere: zigbee2mqtt and zwave hold radio pairing state that is painful to rebuild, and home-assistant is the cluster's largest config surface. Each of these cuts over on its own, after green scheduled snapshots and a restore drill against a scratch PVC — never batched.

Prerequisite #6412 is merged, so `kopiur-repository-secret` already exists in `home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)