### PR TITLE
feat(media): back up the sixteen volsync apps with kopiur

### DIFF
--- a/kubernetes/apps/media/agregarr/ks.yaml
+++ b/kubernetes/apps/media/agregarr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: agregarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: agregarr
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/autobrr/ks.yaml
+++ b/kubernetes/apps/media/autobrr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: autobrr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: bazarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: bazarr
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/board-game-collection/ks.yaml
+++ b/kubernetes/apps/media/board-game-collection/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: board-game-collection
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: board-game-collection
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/booklore/ks.yaml
+++ b/kubernetes/apps/media/booklore/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: booklore
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: booklore
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: music-assistant
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: music-assistant
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: plex
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
@@ -13,6 +14,8 @@ spec:
       namespace: kube-system
     - name: intel-gpu-resource-driver
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -20,6 +23,7 @@ spec:
   postBuild:
     substitute:
       APP: plex
+      KOPIUR_CAPACITY: 30Gi
       VOLSYNC_CAPACITY: 30Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: prowlarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: prowlarr
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: qbittorrent
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: qbittorrent
+      KOPIUR_CAPACITY: 2Gi
       VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: qui
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: qui
+      KOPIUR_CAPACITY: 2Gi
       VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: radarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: radarr
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: recyclarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: recyclarr
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: seerr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: seerr
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: shelfmark
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: shelfmark
+      KOPIUR_CAPACITY: 1Gi
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: sonarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: sonarr
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: tautulli
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -15,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: tautulli
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
Backup phase for every volsync app in the `media` namespace, same shape as #6413 / #6414 / #6415: `components/kopiur/backup` plus the `kopiur-repository` dependency, with volsync left running untouched beside it.

`KOPIUR_CAPACITY` mirrors each app's `VOLSYNC_CAPACITY`; autobrr sets neither and takes the component default of 5Gi, as it does today under volsync.

Since that variable also sizes the mover cache PVC, plex provisions a 30Gi `longhorn-cache` volume per run — the largest in the cluster. Volsync couples `cacheCapacity` to the same variable, so this is not a regression, but it is the one to watch when sixteen policies start running on the same `H 4 * * *` window.

### New lineage, not a continuation

Snapshots land under `<app>@media:/pvc/<app>` rather than continuing volsync's `<app>@media:/data`, following onedr0p's component (see #6413 for the full rationale). The volsync history is therefore **not** a fallback once a cutover deletes a PVC, so each app cuts over on its own after green scheduled snapshots and a restore drill.

Prerequisite #6412 is merged, so `kopiur-repository-secret` already exists in `media`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)