### PR TITLE
feat(development): back up board-game-collection with kopiur

### DIFF
--- a/kubernetes/apps/development/board-game-collection/ks.yaml
+++ b/kubernetes/apps/development/board-game-collection/ks.yaml
@@ -6,8 +6,11 @@ metadata:
   name: board-game-collection
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 30m


### PR DESCRIPTION
Backup phase for the one volsync app in the `development` namespace — the last one missing after #6413 / #6414 / #6415 / #6416 covered `ai`, `default`, `home` and `media`. Same shape: `components/kopiur/backup` plus the `kopiur-repository` dependency, with volsync left running beside it.

It sets no `VOLSYNC_CAPACITY` and takes the component default of 5Gi under both movers, so no `KOPIUR_CAPACITY` is needed either.

As with the other apps, this starts a new kopia lineage under `board-game-collection@development:/pvc/board-game-collection` rather than continuing volsync's `:/data`, following onedr0p's component (see #6413 for the rationale).

Prerequisite #6412 is merged, so `kopiur-repository-secret` already exists in `development`.

With this merged, all 28 volsync apps are dual-writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)