### PR TITLE
fix(kopiur): run each mover as the uid that owns its source PVC

### DIFF
--- a/kubernetes/apps/default/obsidian-couchdb/ks.yaml
+++ b/kubernetes/apps/default/obsidian-couchdb/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: obsidian-couchdb
       KOPIUR_CAPACITY: 30Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"
       VOLSYNC_CAPACITY: 30Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -20,6 +20,8 @@ spec:
     substitute:
       APP: esphome
       KOPIUR_CAPACITY: 5Gi
+      KOPIUR_PUID: "2000"
+      KOPIUR_PGID: "2000"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -26,6 +26,8 @@ spec:
     substitute:
       APP: frigate
       KOPIUR_CAPACITY: 10Gi
+      KOPIUR_PUID: "0"
+      KOPIUR_PGID: "0"
       VOLSYNC_CAPACITY: 10Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -20,6 +20,8 @@ spec:
     substitute:
       APP: matter-server
       KOPIUR_CAPACITY: 5Gi
+      KOPIUR_PUID: "0"
+      KOPIUR_PGID: "0"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/ks.yaml
@@ -20,6 +20,8 @@ spec:
     substitute:
       APP: zigbee2mqtt
       KOPIUR_CAPACITY: 1Gi
+      KOPIUR_PUID: "0"
+      KOPIUR_PGID: "0"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/zwave/ks.yaml
+++ b/kubernetes/apps/home/zwave/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: zwave
       KOPIUR_CAPACITY: 1Gi
+      KOPIUR_PUID: "0"
+      KOPIUR_PGID: "0"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
Four of the six `home` apps failed their first kopiur snapshot with `PermissionDenied`. The mover runs as `KOPIUR_PUID`/`KOPIUR_PGID`, which defaults to 1000, but these workloads don't run as 1000 — and kopia can't read mode-0600 files owned by another uid.

```
esphome         6 fatal errors  (workload runs as 2000)
matter-server   7 fatal errors  (runs as root, pinned)
frigate         1 fatal error   (.jwt_secret, root via the image's USER)
zwave           1 fatal error   (.session-secret, root via USER)
```

Sets `KOPIUR_PUID`/`KOPIUR_PGID` per app to the uid that owns the data.

**Verified** on esphome by patching the live SnapshotPolicy to 2000 and re-running: `Succeeded`, 47,900 files, 2.2 GB — where the 1000 run wrote nothing. Patch reverted afterwards.

### Why zigbee2mqtt and obsidian-couchdb are included

Their snapshots passed, but only because every file happened to be world-readable. One mode-0600 file breaks them the same way. Not worth leaving to chance on radio pairing state and a couchdb data directory.

### Audit

All 28 policies checked against their workload's effective uid (pod spec where pinned, `id -u` in the running container otherwise). The remaining 22 genuinely run as 1000 — hermes at 10000, already set — so they need no override.

| App | Workload UID | Was | Now |
|---|---|---|---|
| esphome | 2000 (pinned) | 1000 | 2000 |
| matter-server | 0 (pinned) | 1000 | 0 |
| frigate | 0 (image `USER`) | 1000 | 0 |
| zwave | 0 (image `USER`) | 1000 | 0 |
| zigbee2mqtt | 0 (image `USER`) | 1000 | 0 |
| obsidian-couchdb | 568 (image `USER`) | 1000 | 568 |

### Worth knowing

Volsync backs these same six apps up with `VOLSYNC_PUID` at the same default 1000 and reports `OPERATION_RESULT: SUCCESS` every night — so its snapshots for them are likely missing exactly these files. Not fixed here (volsync is being decommissioned, and its history isn't a restore fallback anyway since kopiur writes a separate lineage), but it's a reason to distrust those volsync snapshots.

After merge the four failed policies need a re-run to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)