### PR TITLE
feat(home): opt the namespace in to privileged kopiur movers

### DIFF
--- a/kubernetes/apps/home/namespace.yaml
+++ b/kubernetes/apps/home/namespace.yaml
@@ -4,4 +4,5 @@ kind: Namespace
 metadata:
   name: _
   annotations:
+    kopiur.home-operations.com/privileged-movers: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
#6418 set `KOPIUR_PUID`/`KOPIUR_PGID` to 0 for frigate, matter-server, zwave and zigbee2mqtt, because those workloads run as root and own their data as root. kopiur will not mint a root mover unless the namespace opts in, so all four have sat `Pending` since — around 8h on their manual runs and 2.5h on the scheduled ones, requeuing every 5 minutes on the same guard.

They are the last four apps in the cluster without a valid kopiur snapshot. The other 25 policies all took a clean scheduled snapshot overnight.

### The guard

kopiur mints a `kopiur-mover` ServiceAccount per namespace. It refuses to run that mover as root unless a cluster admin annotates the namespace, so that a tenant with access to the namespace cannot reuse the ServiceAccount at root privilege.

This is a single-tenant homelab, and the four workloads already run as root — zwave and zigbee2mqtt privileged, for USB radio access. The mover gains nothing they do not already have.

Scoped to `home` deliberately: no app in `ai`, `default`, `development` or `media` needs a root mover, and the annotation is per namespace.

After merge the four Pending snapshots should proceed; they need a re-run to confirm, and their partial adopted snapshots (matter-server 3.2 KB, zwave 7.3 MB, frigate 886 MB, left behind by the failed runs before #6418) should then be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
