### PR TITLE
feat(atuin): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: atuin
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
First cutover after actual (#6155): swaps `components/volsync` for `components/kopiur/restore`, so kopiur's Restore populator owns the volume and volsync is gone for this app.

atuin is deliberately first: 4 files and 185 MB, the smallest surface in the cluster, so it exercises the delete-and-repopulate runbook cheaply before anything larger.

Flux prunes atuin's ReplicationSource, ReplicationDestination, ExternalSecret/Secret and volsync's own two PVCs. The data PVC is declared by both components under the same name, so it stays in Flux's inventory and is never pruned — which is why a PVC's immutable `dataSourceRef` has to be dealt with out of band.

### ⚠️ Merge sequence

Do not merge this on its own. As with actual:

1. verify a green kopiur snapshot and a restore drill against a scratch PVC
2. scale the app to 0
3. `kubectl delete pvc atuin`
4. **merge this** — Flux applies the kopiur PVC and the populator restores from the latest snapshot
5. scale up and verify

Step 3 is the point of no return: longhorn reclaims on delete, so from there the kopiur snapshot is the only copy. Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
