### PR TITLE
feat(default): drop volsync for thelounge and board-game-collection

### DIFF
--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system

--- a/kubernetes/apps/development/board-game-collection/ks.yaml
+++ b/kubernetes/apps/development/board-game-collection/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system


### PR DESCRIPTION
Cuts thelounge (default) and board-game-collection (development) over to `components/kopiur/restore`, dropping volsync for both.

Batched because both are small config-only volumes with no live database, the lowest-risk pair left after atuin.

### ⚠️ Merge sequence

Each app cuts over with the runbook proven on atuin (#6421):

1. verify a green kopiur snapshot for the app
2. `kubectl scale deploy <app> --replicas=0`
3. **take a cold snapshot** — `kubectl kopiur snapshot now --policy <app>` with the app stopped, so a live database is captured checkpointed and consistent
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims immediately and the kopiur snapshot becomes the only copy
5. **merge this** — Flux applies the kopiur PVC and the populator restores
6. scale up and verify

Merging before step 4 is safe but unhelpful: Flux's dry-run rejects the immutable `dataSourceRef` and blocks the whole apply, leaving a red Kustomization until the PVC is gone.

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
