### PR TITLE
feat(media): drop volsync for the seven config-only apps

### DIFF
--- a/kubernetes/apps/media/autobrr/ks.yaml
+++ b/kubernetes/apps/media/autobrr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository

--- a/kubernetes/apps/media/board-game-collection/ks.yaml
+++ b/kubernetes/apps/media/board-game-collection/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: board-game-collection
       KOPIUR_CAPACITY: 1Gi
-      VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: prowlarr
       KOPIUR_CAPACITY: 1Gi
-      VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: qui
       KOPIUR_CAPACITY: 2Gi
-      VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: recyclarr
       KOPIUR_CAPACITY: 1Gi
-      VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: shelfmark
       KOPIUR_CAPACITY: 1Gi
-      VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: tautulli
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts recyclarr, prowlarr, shelfmark, board-game-collection, autobrr, qui and tautulli over to `components/kopiur/restore`.

Batched because all seven are small config-only volumes (1-5Gi) whose state rebuilds from upstream sources if anything goes wrong - the cheapest group to move in one pass.

### ⚠️ Merge sequence

Each app cuts over with the runbook proven on atuin (#6421):

1. verify a green kopiur snapshot for the app
2. `kubectl scale deploy <app> --replicas=0`
3. **take a cold snapshot** — `kubectl kopiur snapshot now --policy <app>` with the app stopped, so a live database is captured checkpointed and consistent
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims immediately and the kopiur snapshot becomes the only copy
5. **merge this** — Flux applies the kopiur PVC and the populator restores
6. scale up and verify

Merging before step 4 is safe but unhelpful: Flux's dry-run rejects the immutable `dataSourceRef` and blocks the whole apply, leaving a red Kustomization until the PVC is gone.

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
