### PR TITLE
feat(media): drop volsync for the *arr apps with live databases

### DIFF
--- a/kubernetes/apps/media/agregarr/ks.yaml
+++ b/kubernetes/apps/media/agregarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: agregarr
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: bazarr
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/booklore/ks.yaml
+++ b/kubernetes/apps/media/booklore/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: booklore
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: music-assistant
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: radarr
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: seerr
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: sonarr
       KOPIUR_CAPACITY: 5Gi
-      VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts sonarr, radarr, bazarr, seerr, agregarr, booklore and music-assistant over to `components/kopiur/restore`.

Batched separately from #6423 because each of these carries a live SQLite database, so every one needs the cold snapshot in step 3 - taken with the app scaled to 0, so the database is captured checkpointed rather than mid-write.

### ⚠️ Merge sequence

Each app cuts over with the runbook proven on atuin (#6421):

1. verify a green kopiur snapshot for the app
2. `kubectl scale deploy <app> --replicas=0`
3. **take a cold snapshot** — `kubectl kopiur snapshot now --policy <app>` with the app stopped, so a live database is captured checkpointed and consistent
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims immediately and the kopiur snapshot becomes the only copy
5. **merge this** — Flux applies the kopiur PVC and the populator restores
6. scale up and verify

Merging before step 4 is safe but unhelpful: Flux's dry-run rejects the immutable `dataSourceRef` and blocks the whole apply, leaving a red Kustomization until the PVC is gone.

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
