### PR TITLE
feat(obsidian-couchdb): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/default/obsidian-couchdb/ks.yaml
+++ b/kubernetes/apps/default/obsidian-couchdb/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -21,7 +21,6 @@ spec:
       KOPIUR_CAPACITY: 30Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"
-      VOLSYNC_CAPACITY: 30Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts obsidian-couchdb over to `components/kopiur/restore`.

Individual because it is the sync target for the Obsidian vaults - a CouchDB data directory with no other copy in the cluster. Its mover also runs as uid 568 (#6418), so watch that the restored volume comes back with usable ownership before scaling up.


### ⚠️ Merge sequence — merge FIRST

Corrected after #6424: merging must come **before** the PVC is deleted. Deleting first leaves a window where Flux still wants the volsync spec and re-provisions the PVC from volsync's ReplicationDestination — which happened to five of the seven apps in #6424, restoring stale volsync-lineage data and re-blocking Flux on the immutable `dataSourceRef`.

1. **merge this** — Flux stalls harmlessly on the immutable `dataSourceRef`; nothing is pruned and the app keeps running
2. `kubectl scale deploy <app> --replicas=0`
3. **cold snapshot** — `kubectl kopiur snapshot now --policy <app>`, app stopped, so a live database is captured checkpointed
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims and the kopiur snapshot becomes the only copy
5. `flux reconcile kustomization <app>` — applies the kopiur spec; the populator restores
6. scale up and verify

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
