### PR TITLE
feat(hermes): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: kopiur-repository
       namespace: kopiur-system
@@ -22,9 +22,6 @@ spec:
       KOPIUR_CAPACITY: 10Gi
       KOPIUR_PUID: "10000"
       KOPIUR_PGID: "10000"
-      VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_PUID: "10000"
-      VOLSYNC_PGID: "10000"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts hermes over to `components/kopiur/restore`.

Individual because it is the largest volume outside media (27,759 files, 5.9GB) and the only app whose mover runs as uid 10000.


### ⚠️ Merge sequence — merge FIRST

Corrected after #6424: merging must come **before** the PVC is deleted. Deleting first leaves a window where Flux still wants the volsync spec and re-provisions the PVC from volsync's ReplicationDestination — which happened to five of the seven apps in #6424, restoring stale volsync-lineage data and re-blocking Flux on the immutable `dataSourceRef`.

1. **merge this** — Flux stalls harmlessly on the immutable `dataSourceRef`; nothing is pruned and the app keeps running
2. `kubectl scale deploy <app> --replicas=0`
3. **cold snapshot** — `kubectl kopiur snapshot now --policy <app>`, app stopped, so a live database is captured checkpointed
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims and the kopiur snapshot becomes the only copy
5. `flux reconcile kustomization <app>` — applies the kopiur spec; the populator restores
6. scale up and verify

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
