### PR TITLE
feat(plex): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: csi-driver-nfs
@@ -24,7 +24,6 @@ spec:
     substitute:
       APP: plex
       KOPIUR_CAPACITY: 30Gi
-      VOLSYNC_CAPACITY: 30Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts plex over to `components/kopiur/restore`.

Individual because it is by far the largest volume in the cluster: 19,891 files, 22.4GB of library metadata and transcoder state. The restore will take substantially longer than every other app, and its 30Gi mover cache is already the heaviest per-run cost in the repository.


### ⚠️ Merge sequence — merge FIRST

Corrected after #6424: merging must come **before** the PVC is deleted. Deleting first leaves a window where Flux still wants the volsync spec and re-provisions the PVC from volsync's ReplicationDestination — which happened to five of the seven apps in #6424, restoring stale volsync-lineage data and re-blocking Flux on the immutable `dataSourceRef`.

1. **merge this** — Flux stalls harmlessly on the immutable `dataSourceRef`; nothing is pruned and the app keeps running
2. `kubectl scale deploy <app> --replicas=0`
3. **cold snapshot** — `kubectl kopiur snapshot now --policy <app>`, app stopped, so a live database is captured checkpointed
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims and the kopiur snapshot becomes the only copy
5. `flux reconcile kustomization <app>` — applies the kopiur spec; the populator restores
6. scale up and verify

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
