### PR TITLE
feat(home-assistant): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
   dependsOn:
     - name: multus-networks
       namespace: kube-system
@@ -22,7 +22,6 @@ spec:
     substitute:
       APP: home-assistant
       KOPIUR_CAPACITY: 10Gi
-      VOLSYNC_CAPACITY: 10Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Cuts home-assistant over to `components/kopiur/restore`.

Individual because it is the largest config surface in the cluster (15,548 files, 7.1GB) and everything in `home` depends on it. It also holds a live SQLite recorder database, so the cold snapshot in step 3 is not optional.


### ⚠️ Merge sequence — merge FIRST

Corrected after #6424: merging must come **before** the PVC is deleted. Deleting first leaves a window where Flux still wants the volsync spec and re-provisions the PVC from volsync's ReplicationDestination — which happened to five of the seven apps in #6424, restoring stale volsync-lineage data and re-blocking Flux on the immutable `dataSourceRef`.

1. **merge this** — Flux stalls harmlessly on the immutable `dataSourceRef`; nothing is pruned and the app keeps running
2. `kubectl scale deploy <app> --replicas=0`
3. **cold snapshot** — `kubectl kopiur snapshot now --policy <app>`, app stopped, so a live database is captured checkpointed
4. `kubectl delete pvc <app>` — irreversible; longhorn reclaims and the kopiur snapshot becomes the only copy
5. `flux reconcile kustomization <app>` — applies the kopiur spec; the populator restores
6. scale up and verify

Volsync's own history is not a fallback — kopiur writes a separate lineage (see #6413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
