### PR TITLE
fix(kopiur): restore volumes with the uid the backup ran as

### DIFF
--- a/kubernetes/components/kopiur/restore/restore.yaml
+++ b/kubernetes/components/kopiur/restore/restore.yaml
@@ -5,6 +5,9 @@ kind: Restore
 metadata:
   name: ${APP}
 spec:
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
   policy:
     onMissingSnapshot: Continue
   source:


### PR DESCRIPTION
qui crash-looped after its cutover in #6423:

```
failed to secure database file /config/qui.db: chmod /config/qui.db: operation not permitted
```

The restore component sets no mover security context, so the restore mover runs as its image's default **65532** and every restored file lands owned by `65532:1000`. Apps that only read and write their data don't notice — the group bits are enough, which is why atuin, thelounge and the other six were fine — but qui `chmod`s its database at startup, and a process can't chmod a file it doesn't own.

Sets `mover.inheritSecurityContextFrom.snapshot` on the Restore, which takes the uid/gid/fsGroup **recorded on the backup itself** (decoded from the `kopiur-meta` kopia tag) rather than from a live workload. That's per-app correct with no new substitution variables — 1000 for most, 2000 for esphome, 568 for obsidian-couchdb, 10000 for hermes, 0 for the four root apps in `home` — and the CRD documents it as the option that works with `target.populator` and on a rebuilt cluster, where no workload pod exists to inherit from.

The backup component already pins its mover context via `KOPIUR_PUID`/`KOPIUR_PGID` (#6418); this closes the same gap on the restore side.

### After merge

qui needs its volume repopulated to pick up correct ownership:

```
kubectl delete pvc qui -n media     # its snapshot is intact; restore is idempotent
flux reconcile kustomization qui -n media
kubectl scale deploy qui -n media --replicas=1
```

The other already-restored volumes keep their 65532 ownership until their PVCs are next repopulated. Only qui is actually broken by it, so the rest are left alone rather than churned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
