### PR TITLE
fix(frigate): back up with gid 1000 so restores stay group-writable

### DIFF
--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -27,7 +27,7 @@ spec:
       APP: frigate
       KOPIUR_CAPACITY: 10Gi
       KOPIUR_PUID: "0"
-      KOPIUR_PGID: "0"
+      KOPIUR_PGID: "1000"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
frigate's `init-config` container crash-looped after its cutover:

```
/bin/sh: can't create /config/config.yml.tmp: Permission denied
cp: can't create '/config/config.yml': File exists
```

The mover runs as `0:0` with `fsGroup: 0` (#6418), so the snapshot records that identity (`recorded uid=0 gid=0 fsGroup=0`) and #6436's inherited restore context recreates `/config` owned `root:root`, group 0. But `init-config` is the `mikefarah/yq` image, which runs as **uid 1000** — it can't write there. Volsync's restore mover ran as `1000:1000`, which is why this worked before.

Keeps `KOPIUR_PUID` at 0, so the backup mover still reads root-owned mode-0600 files like `.jwt_secret` (uid 0 bypasses permissions), and moves `KOPIUR_PGID` to 1000, so the recorded fsGroup makes the restored volume group-1000 writable. Both the root app container and the non-root init container can then write.

### Why not `fsGroup: 1000` on the pod

`fsGroup` applies to **every** volume in the pod, including frigate's NFS media mount — that would risk a recursive chown across the whole media share. The backup-side change touches only the kopiur volume.

frigate is the only app with a non-root init container over a kopiur-restored volume; zwave, zigbee2mqtt, matter-server and home-assistant have no `initContainers` at all.

### After merge

frigate's data is intact in the current PVC, so it needs a re-snapshot to record the new identity, then a repopulate:

```
kubectl kopiur snapshot now --policy frigate -n home     # records fsGroup 1000
kubectl delete pvc frigate -n home
flux reconcile kustomization frigate -n home
kubectl scale deploy frigate -n home --replicas=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
