### PR TITLE
fix(kopiur): cap mover cache budgets so the sweeper actually runs

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -23,5 +23,9 @@ spec:
       key: KOPIA_PASSWORD
   maintenance:
     enabled: false # volsync's KopiaMaintenance still owns compaction
+  moverDefaults:
+    cache:
+      contentCacheSizeMb: 512
+      metadataCacheSizeMb: 1024
   scheduleDefaults:
     timezone: America/Santiago


### PR DESCRIPTION
Three movers wedged today — esphome overnight, zwave twice — each hanging indefinitely right after `loaded work spec`, idle at 1m CPU, never reaching the repository. Deleting the mover's cache PVC and retrying made zwave snapshot **in under 30 seconds**: 2,396 files, 7.3 MB.

Kopia defaults to a 5000 MiB budget per cache. `KOPIUR_CAPACITY` sizes both the data PVC *and* the mover cache, so apps like zwave and zigbee2mqtt get a **1Gi** cache — far under the budget, so kopia's sweeper never fires, the cache fills the volume, and the mover blocks instead of failing.

Sets the budgets on the ClusterRepository, which applies to every mover without touching per-app `KOPIUR_CAPACITY`. Values match onedr0p's, whose comment describes the same trap:

> Every cache PVC is 5Gi or larger (KOPIUR_CAPACITY default). Kopia's own defaults are 5000 MiB per budget, larger than the whole PVC, so the sweeper never runs and the cache fills the volume. The metadata budget applies twice: kopia caps the index-blobs cache at the same size.

### Not retroactive

The budget governs sweeping, not a purge — cache PVCs that already filled stay full. Any mover still wedged after this needs its `kopiur-cache-<app>` PVC deleted once:

```
kubectl delete pvc kopiur-cache-<app> -n <ns>
```

They're disposable and kopiur recreates them. zwave's was already cleared this way; `kopiur-cache-zigbee2mqtt` (also 1Gi) is the next most likely to need it.

Smallest cache PVCs in the cluster, all at risk: zwave, zigbee2mqtt, prowlarr, recyclarr, shelfmark, board-game-collection (1Gi); qbittorrent, qui (2Gi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
