### PR TITLE
feat(kopiur): keep the snapshot catalog self-healing

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -14,6 +14,9 @@ spec:
         nfs:
           server: black-station.internal
           path: /volume1/VolsyncKopia
+  catalog:
+    periodicRefresh: true
+    refreshInterval: 6h
   create:
     enabled: false
   encryption:


### PR DESCRIPTION
Deleting the volsync-era snapshots from the repository left **462 `discovered` Snapshot CRs** pointing at objects that no longer existed. `catalog.periodicRefresh` is off by default, so kopiur never re-scans and they persisted in etcd until a manual `kopiur.home-operations.com/catalog-scan-requested-at` annotation cleared them.

Enables periodic refresh so the catalog reconciles itself.

`refreshInterval: 6h` rather than the 1h default: for a volume-backed repository each refresh recycles the `nas-discovery` mover Job, and the catalog only drifts when snapshots are deleted out of band — rare now that the migration is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
