### PR TITLE
feat(kopiur): compress snapshots with zstd

### DIFF
--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ${APP}
 spec:
   compression:
-    compressor: zstd-fastest
+    compressor: zstd
   copyMethod: Snapshot
   mover:
     cache:


### PR DESCRIPTION
`zstd-fastest` was inherited from volsync, whose ReplicationSources all pinned it. It was carried over in #6147 so kopiur's snapshots matched what volsync already wrote rather than silently changing compression mid-migration. That reason is gone now that volsync is.

Moves to plain `zstd`, matching onedr0p. Better ratio for a little more CPU in the mover, which is a good trade here — the movers are I/O bound against NFS, not CPU bound, and these are daily backups of mostly small config volumes.

### Scope

Only affects blobs written from here on. Kopia compresses per blob, so existing snapshots keep their current compression and nothing is rewritten; the repository just gradually shifts as new content lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
