### PR TITLE
feat(kopiur): widen retention and cap the operator's memory

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -39,3 +39,5 @@ spec:
       requests:
         cpu: 100m
         memory: 128Mi
+      limits:
+        memory: 2Gi

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -22,8 +22,10 @@ spec:
     kind: ClusterRepository
     name: nas
   retention:
+    keepLatest: 3
     keepHourly: 24
     keepDaily: 7
+    keepWeekly: 4
   sources:
     - pvc:
         name: ${APP}


### PR DESCRIPTION
Two gaps found comparing against onedr0p after the migration.

### Retention

Inherited from volsync's `retain` block — `keepHourly: 24`, `keepDaily: 7` — and never revisited. On a **daily** schedule those hourly slots each hold one day, so effective history is ~24 days (actual has exactly 24 snapshots after 46 days of dailies). Workable, but there's no weekly tail and no floor guaranteeing recent snapshots if the schedule stalls.

Adds onedr0p's `keepLatest: 3` and `keepWeekly: 4`:

```yaml
retention:
  keepLatest: 3     # floor, regardless of time buckets
  keepHourly: 24
  keepDaily: 7
  keepWeekly: 4     # extends history to ~1 month
```

Retention changes apply on the next maintenance run and *can* prune — but both new tiers only ever retain more, so nothing is dropped that would have survived before.

### Operator memory limit

The operator had a memory request and no limit, so it could balloon unbounded on a node. Adds onedr0p's `limits.memory: 2Gi`. Request stays at 128Mi; the controller idles well below it.

### Not adopted

`parameters.epoch.minDuration: 1h` — onedr0p sets it, we don't. Left alone as index-compaction tuning we have no evidence of needing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
